### PR TITLE
Fix link to Reason React

### DIFF
--- a/src/pages/guide/javascript/quickstart.md
+++ b/src/pages/guide/javascript/quickstart.md
@@ -21,6 +21,6 @@ That's all! This compiles Reason to Javascript in the `lib/js/` folder.
 
 - Read more about how we compile to JavaScript through our partner project, [BuckleScript](http://bucklescript.github.io/bucklescript/Manual.html).
 
-- Alternatively, **to start a [ReasonReact](https://reasonml.github.io/reason-react/gettingStarted.html) app**, try `bsb -init my-react-app -theme react`.
+- Alternatively, **to start a [ReasonReact](https://reasonml.github.io/reason-react/docs/en/installation.html) app**, try `bsb -init my-react-app -theme react`.
 
 - Head over to [Editor Setup](/guide/editor-tools/global-installation) to get the Reason plugin for your favorite editor!


### PR DESCRIPTION
The link is out of date, when navigated to it proposes this new link